### PR TITLE
Add GitHub Action to install PyAudio

### DIFF
--- a/.github/workflows/pip_install_pyaudio.yml
+++ b/.github/workflows/pip_install_pyaudio.yml
@@ -15,7 +15,7 @@ jobs:
         python-version: [3.13, 3.14]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/pip_install_pyaudio.yml
+++ b/.github/workflows/pip_install_pyaudio.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:  # https://github.com/CristiFati/pyaudio/blob/master/INSTALL
         # macos-13 in Intel, macos-latest is Apple Silicon ARM
-        os: [macos-13, macos-latest, ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm]
+        os: [macos-15-intel, macos-latest, ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm]
         python-version: [3.13, 3.14]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/pip_install_pyaudio.yml
+++ b/.github/workflows/pip_install_pyaudio.yml
@@ -1,0 +1,39 @@
+# A GitHub Action to demonstrate how to run pyaudio on Python 3.13 on Windows 11 on ARM.
+# A GitHub Action to demonstrate how to run pyaudio on Python 3.14 before its release in Oct. 2024
+name: pip_install_pyaudio
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  pip_install_pyaudio:
+    strategy:
+      fail-fast: false
+      matrix:  # https://github.com/CristiFati/pyaudio/blob/master/INSTALL
+        # macos-13 in Intel, macos-latest is Apple Silicon ARM
+        os: [macos-13, macos-latest, ubuntu-latest, ubuntu-24.04-arm, windows-latest, windows-11-arm]
+        python-version: [3.13, 3.14]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
+      - if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install --yes portaudio19-dev # libasound-dev python3-pyaudio
+      - if: runner.os == 'macOS'
+        run: |
+          brew install portaudio
+      - if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          systeminfo || true
+          vcpkg install portaudio:x86-windows-static
+          vcpkg install portaudio:x64-windows-static
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyaudio


### PR DESCRIPTION
Similar to #9, but for newer Python versions.
* #9 

This workflow installs PyAudio on various operating systems using Python 3.13 and 3.14.

Python v3.14 -- October 7th
* https://www.python.org/download/pre-releases
* https://www.python.org/downloads/release/python-3140rc3
* #15 

### Test results at https://github.com/cclauss/pyaudio/actions
* `macos-latest` and `ubuntu-latest` pass on both Intel and ARM on both Python 3.13 and 3.14rc2
* `windows-latest` fails on Python 3.14rc3
* `windows-11-arm` fails on Python 3.13 and 3.14rc3